### PR TITLE
Add error classes for PoFile errors

### DIFF
--- a/lib/get_pomo.rb
+++ b/lib/get_pomo.rb
@@ -1,8 +1,13 @@
 require 'get_pomo/po_file'
+
 module GetPomo
   autoload :VERSION, "get_pomo/version"
-  
+
   extend self
+
+  class GetPomo::Error < StandardError; end
+  class GetPomo::InvalidString < GetPomo::Error; end
+  class GetPomo::InvalidMethod < GetPomo::Error; end
 
   # A message is unique if the combination of msgid and msgctxt is unique.
   # An emtpy msgctxt does not mean the same thing as no msgctxt.

--- a/lib/get_pomo/po_file.rb
+++ b/lib/get_pomo/po_file.rb
@@ -106,7 +106,7 @@ module GetPomo
     #msgid "hello" -> method call msgid + add string "hello"
     def parse_method_call(line)
       method, string = line.match(/^\s*([a-z0-9_\[\]]+)(.*)/)[1..2]
-      raise "no method found" unless method
+      raise GetPomo::NoMethodFound, "No method found" unless method
       start_new_translation if %W(msgid msgctxt msgctxt).include? method and translation_complete?
       @last_method = method.to_sym
       add_string(string)
@@ -116,7 +116,7 @@ module GetPomo
     def add_string(string)
       string = string.strip
       return if string.empty?
-      raise "not string format: #{string.inspect} on line #{@line_number}" unless string =~ /^['"](.*)['"]$/
+      raise GetPomo::InvalidString, "Not a string format: #{string.inspect} on line #{@line_number}" unless string =~ /^['"](.*)['"]$/
       string_content = string[1..-2] #remove leading and trailing quotes from content
       @current_translation.add_text(string_content, :to=>@last_method)
     end


### PR DESCRIPTION
RuntimeError doesn't really make sense. We added error classes to be more descriptive.
