### PR TITLE
Added missing hash mark in comments created by to_text()

### DIFF
--- a/lib/get_pomo/po_file.rb
+++ b/lib/get_pomo/po_file.rb
@@ -58,7 +58,7 @@ module GetPomo
       default_options = {:merge => false}
       @options.merge!(default_options.merge(options))
       GetPomo.unique_translations(translations, options[:merge]).map do |translation|
-        comment = translation.comment.to_s.split(/\n|\r\n/).map{|line|"#{line}\n"}*''
+        comment = translation.comment.to_s.split(/\n|\r\n/).map{|line|"##{line}\n"}*''
 
         msgctxt = if translation.msgctxt
           %Q(msgctxt "#{translation.msgctxt}"\n)


### PR DESCRIPTION
Comment lines created by to_text did not start with '#'.